### PR TITLE
Add formats module

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,21 @@ The documentation of all available endpoints can be found [http://localhost:8080
 
 
 ## 🪲 Unit Testing
-Start the server with the command:
-```bash
-npm run start
-```
-Once the dependencies are installed and the backend is running, you can run the tests. To do this, use the command:
 Running all tests:
+
 ```bash
 npm run test
 ```
+
 Run all tests with detailed report:
+
 ```bash
 npm run test:watch
+```
+
+## 🌱 Seeding Data
+Seeds help you fill your database with initial data for a presentation or project launch. To start creating test data, run the command.
+
+```bash
+npm run migrate:seed
 ```

--- a/docs/db/generated/schema.dbml
+++ b/docs/db/generated/schema.dbml
@@ -34,6 +34,15 @@ Table companies {
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime [default: `now()`, not null]
   owner users [not null]
+  events events [not null]
+}
+
+Table event_formats {
+  id Int [pk, increment]
+  title String [unique, not null]
+  createdAt DateTime [default: `now()`, not null]
+  updatedAt DateTime [default: `now()`, not null]
+  events events [not null]
 }
 
 Table events {
@@ -53,6 +62,8 @@ Table events {
   status EventStatus [not null, default: 'DRAFT']
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime [default: `now()`, not null]
+  company companies [not null]
+  format event_formats [not null]
 }
 
 Enum AttendeeVisibility {
@@ -73,3 +84,7 @@ Enum EventStatus {
 Ref: refresh_token_nonces.userId > users.id [delete: Cascade]
 
 Ref: companies.ownerId - users.id [delete: Restrict]
+
+Ref: events.companyId > companies.id [delete: Restrict]
+
+Ref: events.formatId > event_formats.id [delete: Restrict]

--- a/package.json
+++ b/package.json
@@ -96,6 +96,9 @@
         "typescript": "^5.7.3",
         "typescript-eslint": "^8.20.0"
     },
+        "prisma": {
+        "seed": "node dist/prisma/seeds/index.js"
+    },
     "jest": {
         "moduleFileExtensions": [
             "js",

--- a/prisma/migrations/20250409181222_create_formats_table/migration.sql
+++ b/prisma/migrations/20250409181222_create_formats_table/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE `event_formats` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `title` VARCHAR(100) NOT NULL,
+    `created_at` TIMESTAMP(0) NOT NULL DEFAULT CURRENT_TIMESTAMP(0),
+    `updated_at` TIMESTAMP(0) NOT NULL DEFAULT CURRENT_TIMESTAMP(0),
+
+    UNIQUE INDEX `event_formats_title_key`(`title`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateIndex
+CREATE INDEX `events_company_id_fk` ON `events`(`company_id`);
+
+-- CreateIndex
+CREATE INDEX `events_format_id_fk` ON `events`(`format_id`);
+
+-- AddForeignKey
+ALTER TABLE `events` ADD CONSTRAINT `events_company_id_fk` FOREIGN KEY (`company_id`) REFERENCES `companies`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `events` ADD CONSTRAINT `events_format_id_fk` FOREIGN KEY (`format_id`) REFERENCES `event_formats`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -68,7 +68,7 @@ model Company {
 
   // Relations
   owner User @relation(fields: [ownerId], references: [id], onDelete: Restrict, map: "companies_owner_id_fk")
-  // events        Event[]
+  events        Event[]
   // subscriptions Subscription[]
   // news          News[]
 
@@ -77,17 +77,17 @@ model Company {
 }
 
 // // Event Formats model
-// model EventFormat {
-//   id        Int      @id @default(autoincrement())
-//   title     String   @unique @db.VarChar(100)
-//   createdAt DateTime @default(now()) @map("created_at") @db.Timestamp(0)
-//   updatedAt DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamp(0)
-//
-//   // Relations
-//   events Event[]
-//
-//   @@map("event_formats")
-// }
+model EventFormat {
+  id        Int      @id @default(autoincrement())
+  title     String   @unique @db.VarChar(100)
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamp(0)
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at") @db.Timestamp(0)
+
+  // Relations
+  events Event[]
+
+  @@map("event_formats")
+}
 //
 // // Event Themes model
 // model EventTheme {
@@ -123,8 +123,8 @@ model Event {
   updatedAt            DateTime           @default(now()) @updatedAt @map("updated_at") @db.Timestamp(0)
 
   // Relations
-  // company        Company              @relation(fields: [companyId], references: [id], onDelete: Restrict, map: "events_company_id_fk")
-  // format         EventFormat          @relation(fields: [formatId], references: [id], onDelete: Restrict, map: "events_format_id_fk")
+  company              Company            @relation(fields: [companyId], references: [id], onDelete: Restrict, map: "events_company_id_fk")
+  format               EventFormat        @relation(fields: [formatId], references: [id], onDelete: Restrict, map: "events_format_id_fk")
   // attendees      EventAttendee[]
   // tickets        Ticket[]
   // promoCodes     PromoCode[]
@@ -132,8 +132,8 @@ model Event {
   // subscriptions  Subscription[]
   // news           News[]
 
-  // @@index([companyId], map: "events_company_id_fk")
-  // @@index([formatId], map: "events_format_id_fk")
+  @@index([companyId], map: "events_company_id_fk")
+  @@index([formatId], map: "events_format_id_fk")
   @@map("events")
 }
 

--- a/prisma/seeds/formats.ts
+++ b/prisma/seeds/formats.ts
@@ -1,0 +1,20 @@
+export const initialFormats = [
+    {
+      title: 'Conference',
+    },
+    {
+      title: 'Masterclass',
+    },
+    {
+      title: 'Hackathon',
+    },
+    {
+        title: 'Forum',
+    },
+    {
+        title: 'Workshop',
+    },
+    {
+        title: 'Webinar',
+    },
+  ];

--- a/prisma/seeds/index.ts
+++ b/prisma/seeds/index.ts
@@ -1,0 +1,35 @@
+import { FormatsService } from '../../src/formats/formats.service';
+import { initialFormats } from './formats';
+import { DatabaseService } from '../../src/db/database.service';
+import { FormatsRepository } from '../../src/formats/formats.repository';
+
+export const ADMIN_ID = 1_234_567_890;
+class Seeder {
+  constructor(private readonly formatService: FormatsService) {}
+
+  async start() {
+    await this.seedFormats();
+    console.log('Formats were created 🏖️');
+    console.log('Seeding completed 🍹');
+  }
+
+  async seedFormats() {
+    for (const format of initialFormats) {
+      const res = await this.formatService.create(format);
+      console.log(`#Format created: ${res.id}`);
+    }
+  }
+}
+
+function start() {
+  try {
+    console.log('Seeding started 🌱');
+    const seeder = new Seeder(new FormatsService(new FormatsRepository(new DatabaseService())));
+    seeder.start();
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+}
+
+start();

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,6 +13,7 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { DatabaseModule } from './db/database.module';
 import { CompaniesModule } from './companies/companies.module';
 import { EventsModule } from './events/events.module';
+import { FormatsModule } from './formats/formats.module';
 
 @Module({
     imports: [
@@ -32,6 +33,7 @@ import { EventsModule } from './events/events.module';
         SchedulerTasksModule,
         CompaniesModule,
         EventsModule,
+        FormatsModule,
     ],
     controllers: [],
     providers: [],

--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -32,20 +32,6 @@ export class EventsController extends BaseCrudController<Event, CreateEventDto, 
         description: 'List of events',
         type: [Event],
     })
-    @ApiResponse({
-        status: HttpStatus.NOT_FOUND,
-        description: 'Events not found',
-        schema: {
-            type: 'object',
-            properties: {
-                message: {
-                    type: 'string',
-                    description: 'Error message',
-                    example: 'Events not found',
-                },
-            },
-        },
-    })
     async findAll(): Promise<Event[]> {
         return this.eventsService.findAllEvents();
     }

--- a/src/formats/dto/create-format.dto.ts
+++ b/src/formats/dto/create-format.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from "class-validator";
+
+export class CreateFormatDto {
+    @IsString()
+    @IsNotEmpty()
+    title: string;
+}

--- a/src/formats/entities/formats.entity.ts
+++ b/src/formats/entities/formats.entity.ts
@@ -1,0 +1,37 @@
+import { EventFormat as PrismaFormat } from "@prisma/client";
+import { Expose } from "class-transformer";
+import { ApiProperty } from '@nestjs/swagger';
+import { IsId } from '../../common/validators/id.validator';
+import { IsTitle } from '../../common/validators/title.validator';
+
+export const SERIALIZATION_GROUPS = {
+    BASIC: ['basic']
+};
+
+export class Format implements PrismaFormat {
+    @IsId(false)
+    @Expose({ groups: ['basic'] })
+    @ApiProperty({
+        description: 'Event identifier',
+        nullable: false,
+        type: 'number',
+        example: 1,
+    })
+    id: number;
+
+    @IsTitle(false)
+    @Expose({ groups: ['basic'] })
+    @ApiProperty({
+        description: 'Format title',
+        nullable: false,
+        type: 'string',
+        example: 'Conference',
+    })
+    title: string;
+
+    @Expose({ groups: ['confidential'] })
+    createdAt: Date;
+
+    @Expose({ groups: ['confidential'] })
+    updatedAt: Date;
+}

--- a/src/formats/formats.controller.spec.ts
+++ b/src/formats/formats.controller.spec.ts
@@ -1,0 +1,61 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FormatsController } from './formats.controller';
+import { FormatsService } from './formats.service';
+import { Format } from './entities/formats.entity';
+import { NotFoundException } from '@nestjs/common';
+describe('FormatsController', () => {
+  let controller: FormatsController;
+  let formatsService: FormatsService;
+
+  const mockFormat: Partial<Format> = {
+    id: 1,
+    title: 'Conference',
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FormatsController],
+      providers: [
+        {
+          provide: FormatsService,
+          useValue: {
+            findAll: jest.fn().mockResolvedValue([mockFormat]),
+            findById: jest.fn().mockResolvedValue(mockFormat),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<FormatsController>(FormatsController);
+    formatsService = module.get<FormatsService>(FormatsService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('findAll', () => {
+    it('should return all formats', async () => {
+      const result = await controller.findAll();
+
+      expect(result).toEqual([mockFormat]);
+      expect(formatsService.findAll).toHaveBeenCalled();
+    });
+  });
+
+  describe('findById', () => {
+    it('should return a format by ID', async () => {
+      const result = await controller.findById(1);
+
+      expect(result).toEqual(mockFormat);
+      expect(formatsService.findById).toHaveBeenCalledWith(1);
+    });
+
+    it('should throw NotFoundException when format is not found', async () => {
+      jest.spyOn(formatsService, 'findById').mockRejectedValue(new NotFoundException('Format not found'));
+
+      await expect(controller.findById(999)).rejects.toThrow(NotFoundException);
+      expect(formatsService.findById).toHaveBeenCalledWith(999);
+    });
+  });
+});

--- a/src/formats/formats.controller.ts
+++ b/src/formats/formats.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Get, Param, HttpStatus } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags, ApiParam } from '@nestjs/swagger';
+import { FormatsService } from './formats.service';
+import { Format } from './entities/formats.entity';
+import { Public } from '../common/decorators/public.decorator';
+
+@Controller('formats')
+@ApiTags('Formats')
+export class FormatsController {
+    constructor(private readonly formatsService: FormatsService) {}
+
+    @Public()
+    @Get()
+    @ApiOperation({ summary: 'Get all formats' })
+    @ApiResponse({ status: HttpStatus.OK, description: 'List of formats', type: [Format] })
+    async findAll(): Promise<Format[]> {
+        return this.formatsService.findAll();
+    }
+
+    @Public()
+    @Get(':id')
+    @ApiOperation({ summary: 'Get format data' })
+    @ApiParam({
+        required: true,
+        name: 'id',
+        type: 'number',
+        description: 'Format ID',
+        example: 1,
+    })
+    @ApiResponse({ status: HttpStatus.OK, description: 'Successfully retrieve', type: Format })
+    @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Format not found', schema: {
+        type: 'object',
+        properties: {
+            message: { type: 'string', description: 'Error message', example: 'Format not found' },
+        },
+    }})
+    async findById(@Param('id') id: number): Promise<Format> {
+        return this.formatsService.findById(id);
+    }
+}

--- a/src/formats/formats.module.ts
+++ b/src/formats/formats.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { FormatsService } from './formats.service';
+import { FormatsController } from './formats.controller';
+import { FormatsRepository } from './formats.repository';
+@Module({
+  providers: [FormatsService, FormatsRepository],
+  controllers: [FormatsController]
+})
+export class FormatsModule {}

--- a/src/formats/formats.repository.ts
+++ b/src/formats/formats.repository.ts
@@ -1,0 +1,21 @@
+import { Injectable } from "@nestjs/common";
+import { DatabaseService } from "../db/database.service";
+import { Format } from "./entities/formats.entity";
+
+
+@Injectable()
+export class FormatsRepository {
+    constructor(private readonly db: DatabaseService) {}
+
+    async findById(id: number): Promise<Partial<Format> | null> {
+        return this.db.eventFormat.findUnique({ where: { id } });
+    }
+
+    async findAll(): Promise<Partial<Format>[]> {
+        return this.db.eventFormat.findMany();
+    }
+
+    async create(format: Partial<Format>): Promise<Partial<Format>> {
+        return this.db.eventFormat.create({ data: format as any });
+    }
+}

--- a/src/formats/formats.service.spec.ts
+++ b/src/formats/formats.service.spec.ts
@@ -1,0 +1,78 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { FormatsService } from './formats.service';
+import { FormatsRepository } from './formats.repository';
+import { Format } from './entities/formats.entity';
+import { NotFoundException } from '@nestjs/common';
+import { CreateFormatDto } from './dto/create-format.dto';
+
+describe('FormatsService', () => {
+  let service: FormatsService;
+  let repository: FormatsRepository;
+
+  const mockFormat: Partial<Format> = {
+    id: 1,
+    title: 'Conference'
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FormatsService,
+        {
+          provide: FormatsRepository,
+          useValue: {
+            findAll: jest.fn(),
+            findById: jest.fn(),
+            create: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<FormatsService>(FormatsService);
+    repository = module.get<FormatsRepository>(FormatsRepository);
+  });
+
+  describe('findAll', () => {
+    it('should return all formats', async () => {
+        const allFormats = [mockFormat];
+        jest.spyOn(repository, 'findAll').mockResolvedValue(allFormats);
+
+        const result = await service.findAll();
+
+        expect(result).toEqual(allFormats);
+        expect(repository.findAll).toHaveBeenCalled();
+    });
+  });
+
+  describe('findById', () => {
+    it('should return format by id', async () => {
+      const format = { ...mockFormat, id: 1 };
+      jest.spyOn(repository, 'findById').mockResolvedValue(format);
+
+      const result = await service.findById(1);
+
+      expect(result).toEqual(format);
+      expect(repository.findById).toHaveBeenCalledWith(1);
+    });
+
+    it('should throw NotFoundException when format is not found', async () => {
+      jest.spyOn(repository, 'findById').mockResolvedValue(null);
+
+      await expect(service.findById(1)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('create', () => {
+    it('should create a new format', async () => {
+      const createFormatDto: CreateFormatDto = { title: 'Conference' };
+      jest.spyOn(repository, 'create').mockResolvedValue(mockFormat);
+
+      const result = await service.create(createFormatDto);
+
+      expect(result).toEqual(mockFormat);
+      expect(repository.create).toHaveBeenCalledWith(createFormatDto);
+    });
+  });
+});
+

--- a/src/formats/formats.service.ts
+++ b/src/formats/formats.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { FormatsRepository } from './formats.repository';
+import { Format, SERIALIZATION_GROUPS } from './entities/formats.entity';
+import { plainToInstance } from 'class-transformer';
+import { CreateFormatDto } from './dto/create-format.dto';
+@Injectable()
+export class FormatsService {
+    constructor(private readonly formatsRepository: FormatsRepository) {}
+
+    async findAll(): Promise<Format[]> {
+        return plainToInstance(Format, await this.formatsRepository.findAll(), {
+            groups: SERIALIZATION_GROUPS.BASIC,
+        });
+    }
+
+    async findById(id: number): Promise<Format> {
+        const format = await this.formatsRepository.findById(id);
+        if (!format) {
+            throw new NotFoundException('Format not found');
+        }
+        return plainToInstance(Format, format, {
+            groups: SERIALIZATION_GROUPS.BASIC,
+        });
+    }
+
+    async create(format: CreateFormatDto): Promise<Format> {
+        return plainToInstance(Format, await this.formatsRepository.create(format), {
+            groups: SERIALIZATION_GROUPS.BASIC,
+        });
+    }
+}


### PR DESCRIPTION
- Introduced Formats module including controller, service, and repository.
- Added event formats entity and DTO for creating formats.
- Implemented seeding functionality for initial formats data.
- Updated Prisma schema and migrations to support event formats.
- Enhanced API documentation for formats and added unit tests for service and controller.